### PR TITLE
Mark 'result' library as unmaintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@
 - [result](https://github.com/rustedpy/result) ★1653 - (Unmaintained) A simple Rust like Result type for Python 3. Fully type annotated.
 - [Option](https://github.com/MaT1g3R/option) ★91 - Rust-like Option and Result types in Python.
 - [Meiga](https://github.com/alice-biometrics/meiga) ★78 - A simple, typed and monad-based Result type for Python.
-- [maybe](https://github.com/rustedpy/maybe) ★71 - A simple Rust like Maybe type for Python 3. Fully type annotated.
+- [maybe](https://github.com/rustedpy/maybe) ★71 - (Unmaintained) A simple Rust like Maybe type for Python 3. Fully type annotated.
 - [Safetywrap](https://github.com/mplanchard/safetywrap) ★45 - Fully typesafe, Rust-like Result and Option types for Python.
 
 #### Immutable / persistent data structures

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@
 #### Return types
 
 - [returns](https://github.com/dry-python/returns) ★3862 - "Make your functions return something meaningful, typed, and safe!"
-- [result](https://github.com/rustedpy/result) ★1653 - A simple Rust like Result type for Python 3. Fully type annotated.
+- [result](https://github.com/rustedpy/result) ★1653 - (Unmaintained) A simple Rust like Result type for Python 3. Fully type annotated.
 - [Option](https://github.com/MaT1g3R/option) ★91 - Rust-like Option and Result types in Python.
 - [Meiga](https://github.com/alice-biometrics/meiga) ★78 - A simple, typed and monad-based Result type for Python.
 - [maybe](https://github.com/rustedpy/maybe) ★71 - A simple Rust like Maybe type for Python 3. Fully type annotated.


### PR DESCRIPTION
See https://github.com/rustedpy/result